### PR TITLE
Expanding functionality to multiple handy shell functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# aws-mfa-auth
+# aws.sh
 
-set AWS environment variables from get-session-token, for use with MFA
+handy shell functions for working with AWS
 
 source from one's .bashrc/.zshrc - don't execute directly.
 
@@ -8,7 +8,7 @@ source from one's .bashrc/.zshrc - don't execute directly.
 
     export AWS_MFA_SERIAL=arn:aws:iam::123456789012:mfa/johndoe
     export AWS_DEFAULT_PROFILE=dayjob
-    source ~/src/aws-mfa-auth/aws-mfa-auth.sh
+    source ~/src/aws.sh/aws.sh
 
 ## Requirements
 
@@ -18,11 +18,27 @@ source from one's .bashrc/.zshrc - don't execute directly.
 - `AWS_DEFAULT_PROFILE` must be set to your profile if it is not `default`.
 - `AWS_MFA_SERIAL` must be serial or device ID of MFA.
 
+set AWS environment variables from get-session-token, for use with MFA
+
 ## Usage
 
+### awsmfa
+
 ```
-$ aws-mfa-auth
+$ awsmfa
 Tokencode: 123456
 $ aws ec2 ...
 ```
+
+### awsip
+
+$ awsip my-instance
+10.10.10.10
+$
+
+### awssh
+
+$ awssh my-instance 'echo hello from $(hostname)'
+
+hello from ip-10.10.10.10.ec2.internal
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,17 @@ $ aws ec2 ...
 
 ### awsip
 
+```
 $ awsip my-instance
 10.10.10.10
 $
+```
 
 ### awssh
 
+```
 $ awssh my-instance 'echo hello from $(hostname)'
 
 hello from ip-10.10.10.10.ec2.internal
+```
 

--- a/aws.sh
+++ b/aws.sh
@@ -1,5 +1,5 @@
 #
-# aws-mfa-auth.sh - set AWS environment variables from get-session-token
+# aws.sh - Handy shell functions to make working with AWS easier
 #
 # Copyright 2017 Customer Value Partners
 #
@@ -15,7 +15,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-aws-mfa-auth() {
+# return private IP of first instance that matches given name
+awsip() {
+  # verify awscli is installed
+  command -v aws >/dev/null 2>&1 || {
+    echo >&2 "aws not available on PATH.";
+    return 1;
+  }
+
+  host=$1
+  aws ec2 describe-instances \
+    --region us-east-1 \
+    --filters "Name=tag:Name,Values=${host}" \
+    --query 'Reservations[*].Instances[*].[PrivateIpAddress]' \
+    --output text | head -1
+}
+
+awssh() {
+  ip=$1
+  shift
+  ssh $(awsip ${ip}) $@
+}
+
+awsmfa() {
 
     # verify awscli is installed
     command -v aws >/dev/null 2>&1 || {


### PR DESCRIPTION
Now supports the following:

* awsmfa - formerly aws-mfa-auth, now with less typing
* awsip - show the private IP of a particularly named instance
* awssh - ssh to a particularly named instance